### PR TITLE
Allow access to org.eclipse.lsp4e.languages package

### DIFF
--- a/org.eclipse.lsp4e.typescript/.classpath
+++ b/org.eclipse.lsp4e.typescript/.classpath
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins">
+		<accessrules>
+			<accessrule kind="accessible" pattern="org/eclipse/lsp4e/languages/*"/>
+		</accessrules>
+	</classpathentry>
 	<classpathentry kind="src" path="src"/>
-	<classpathentry kind="output" path="bin"/>
+	<classpathentry kind="output" path="target/classes"/>
 </classpath>


### PR DESCRIPTION
Resolves access restriction error

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>